### PR TITLE
Make demo work with alpine

### DIFF
--- a/docker/demo-rais-entry.sh
+++ b/docker/demo-rais-entry.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # demo-rais-entry.sh is the RAIS entrypoint script, which sets up the
 # configuration and runs the rais server
@@ -6,7 +6,7 @@
 # Copy the config and edit it in-place; this allows customizing most pieces of
 # configuration for demoing
 url=${URL:-}
-if [[ $url == "" ]]; then
+if test "$url" == ""; then
   echo "No URL provided; defaulting to 'http://localhost'"
   echo "If you can't see images, try an explicitly-set URL, e.g.:"
   echo


### PR DESCRIPTION
If you specify (in the docker-compose.override.yml) that you want to use
the alpine image for the demo, the entrypoint has to work with sh, not
use bash-specific testing.  This makes that possible.