### PR TITLE
Remove experimental DZI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ source, no-commercial-products-required, proof-of-concept tile server for JP2
 images within [chronam](https://github.com/LibraryOfCongress/chronam).
 
 It has been updated to allow more command-line options, more source file
-formats, more features, conformance to the [IIIF](http://iiif.io/) spec, and
-experimental DeepZoom support.
+formats, more features, and conformance to the [IIIF](http://iiif.io/) spec.
 
 RAIS is very efficient, completely free, and easy to set up and run.  See our
 [wiki](https://github.com/uoregon-libraries/rais-image-server/wiki) pages for

--- a/docker/demo-web-entry.sh
+++ b/docker/demo-web-entry.sh
@@ -20,16 +20,4 @@ for file in $(find /var/local/images -name "*.jp2" -o -name "*.tiff" -o -name "*
 done
 sed "s|%SRCS%|$sources|g" /usr/share/nginx/html/template.html > /usr/share/nginx/html/iiif.html
 
-sources=""
-for file in $(find /var/local/images -name "*.jp2" -o -name "*.tiff" -o -name "*.jpg"); do
-  relpath=${file##/var/local/images/}
-  relpath=${relpath//\//%2F}
-  if [[ $sources != "" ]]; then
-    sources="$sources,"
-  fi
-
-  sources="$sources\"/images/dzi/${relpath}.dzi\""
-done
-sed "s|%SRCS%|$sources|g" /usr/share/nginx/html/template.html > /usr/share/nginx/html/dzi.html
-
 exec nginx -g "daemon off;"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -2,14 +2,6 @@ server {
     listen       80;
     server_name  localhost;
 
-    location /images/dzi {
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header X-Forwarded-Host $remote_addr;
-        proxy_pass http://rais:12415;
-    }
-
     location /images/iiif {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/docker/static/index.html
+++ b/docker/static/index.html
@@ -3,10 +3,6 @@
   <title>OpenSeadragon Demo - RAIS Image Server</title>
 </head>
 <body>
-  Pick your poison:
-  <ul>
-    <li><a href="/iiif.html">Test images in <code>docker/images</code> via IIIF</a></li>
-    <li><a href="/dzi.html">Test images in <code>docker/images</code> via DeepZoom</a></li>
-  </ul>
+  <a href="/iiif.html">Test images in <code>docker/images</code></a>
 </body>
 </html>

--- a/src/cmd/rais-server/main.go
+++ b/src/cmd/rais-server/main.go
@@ -86,7 +86,6 @@ func main() {
 	var pubSrv = servers.New("RAIS", address)
 	pubSrv.AddMiddleware(logMiddleware)
 	handle(pubSrv, ih.IIIFBase.Path+"/", http.HandlerFunc(ih.IIIFRoute))
-	handle(pubSrv, "/images/dzi/", http.HandlerFunc(ih.DZIRoute))
 	handle(pubSrv, "/", http.NotFoundHandler())
 
 	var admSrv = servers.New("RAIS Admin", adminAddress)


### PR DESCRIPTION
Seems like could add unnecessary pain when trying to update the interface to stream rather than open things by filepath.  Given the proliferation of IIIF viewers and servers, seems like DZI support is no longer valuable for the extra maintenance it causes.