### PR TITLE
fix opjMinusOneSizeT type mismatch

### DIFF
--- a/src/openjpeg/image_stream.go
+++ b/src/openjpeg/image_stream.go
@@ -55,7 +55,7 @@ func opjStreamRead(writeBuffer unsafe.Pointer, numBytes C.OPJ_SIZE_T, id uint64)
 	var i, ok = lookupImage(id)
 	if !ok {
 		Logger.Errorf("Unable to find stream %d", id)
-		return opjMinusOne64
+		return opjMinusOneSizeT
 	}
 
 	var data []byte
@@ -77,7 +77,7 @@ func opjStreamRead(writeBuffer unsafe.Pointer, numBytes C.OPJ_SIZE_T, id uint64)
 		if err != io.EOF {
 			Logger.Errorf("Unable to read from stream %d: %s", id, err)
 		}
-		return opjMinusOne64
+		return opjMinusOneSizeT
 	}
 
 	return C.OPJ_SIZE_T(n)


### PR DESCRIPTION
In src/openjpeg/image_stream.go, the value returned by opjStreamRead is opjMinusOne64 (type OPJ_UINT64), which seemingly mismatches the return type OPJ_SIZE_T under some compiling systems.

The compilation fails in local golang environment under MacOS Catalina with brew module openjpeg installed and used as a library. The problem is fixed after changing return value to opjMinusOneSizeT.

I think the reason it goes well in docker environment (both alpine and golang) is maybe that the two types references to the same type in ibopenjp2-7-dev. But in my MacOS local environment, the two types confirmed are u_longlong and u_long respectively.
