### PR TITLE
s3demo/Dockerfile: remove upx

### DIFF
--- a/docker/s3demo/Dockerfile
+++ b/docker/s3demo/Dockerfile
@@ -1,13 +1,11 @@
 FROM golang:1 as build-env
 RUN apt-get update
-RUN apt-get install -y upx-ucl
 WORKDIR /s3demo
 ADD s3demo/go.mod /s3demo/go.mod
 ADD s3demo/go.sum /s3demo/go.sum
 RUN go mod download
 ADD ./s3demo/*.go /s3demo/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o server
-RUN upx ./server
 
 FROM alpine
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*


### PR DESCRIPTION
UPX is a tool to reduce binary sizes. Which is totally unnecessary for the S3 demo, which is already very small anyway. And it no longer works without some mucking about, so... bye!