### PR TITLE
Change example systemd unit to add restarting

### DIFF
--- a/rh_config/rais.service
+++ b/rh_config/rais.service
@@ -1,10 +1,15 @@
 [Unit]
 	Description=RAIS image server
 	After=sysinit.target
+	StartLimitIntervalSec=0
 
 [Service]
 	Type=simple
 	ExecStart=/usr/local/rais/rais-server
+	Restart=on-failure
+	RestartSec=5
+	StartLimitBurst=5
+	StartLimitIntervalSec=0
 
 [Install]
 	WantedBy=multi-user.target


### PR DESCRIPTION
Not sure how we missed this for so long, but this ensures that if anything kills RAIS (say the system OOM-killer), it'll restart shortly thereafter, which is what we want pretty much 100% of the time.