### PR TITLE
Verify CGo is available before compiling RAIS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,16 @@ MakefileDir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 BUILD := $(shell git describe --tags)
 
 # Default target builds binaries
-all: binaries
+all: cgo binaries
 
 # Security check
 .PHONY: audit
 audit:
 	go tool govulncheck ./src/...
+
+.PHONY: cgo
+cgo:
+	./scripts/can_cgo.sh
 
 # Generated code
 generate: src/transform/rotation.go

--- a/scripts/can_cgo.sh
+++ b/scripts/can_cgo.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ $(go env CGO_ENABLED) != '1' ]]; then
+  echo "Your system cannot build RAIS. It appears that there may not be a C compiler,"
+  echo "which is required for the openjpeg bindings. Install gcc, clang, or similar"
+  echo "and try again."
+
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This only affects whether `make` tries to continue building, not the behavior or functionality of RAIS