### PR TITLE
Fix/invalid rotation should error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,10 @@ rais-server:
 jp2info:
 	go build -ldflags="-s -w -X rais/src/version.Version=$(BUILD)" -o ./bin/jp2info rais/src/cmd/jp2info
 
-# Testing
+# Testing; imagick plugins are excluded because they need ImageMagick dev
+# libraries, which we don't want to require for routine test runs / CI
 test:
-	go test rais/src/...
+	go test $$(go list ./src/... | grep -v 'src/plugins/imagick')
 
 bench:
 	go test -bench=. -benchtime=5s -count=2 rais/src/openjpeg rais/src/cmd/rais-server
@@ -43,9 +44,14 @@ bench:
 format:
 	find src/ -name "*.go" | xargs gofmt -l -w -s
 
-lint:
+# Vet skips the imagick plugins for the same reason "test" does: vet has to
+# compile cgo packages, and we don't want ImageMagick required everywhere
+.PHONY: vet
+vet:
+	go vet $$(go list ./src/... | grep -v 'src/plugins/imagick')
+
+lint: vet
 	go tool revive src/...
-	go vet rais/src/...
 
 # Cleanup
 clean:

--- a/src/iiif/rotation.go
+++ b/src/iiif/rotation.go
@@ -12,12 +12,13 @@ type Rotation struct {
 	Degrees float64
 }
 
-// StringToRotation creates a Rotation from a string as seen in a IIIF URL.
-// An invalid string would result in a 0-degree rotation as opposed to an error
-// condition.  This is a known issue which needs to be fixed.
+// StringToRotation creates a Rotation from a string as seen in a IIIF URL. A
+// string which can't be parsed as a number (after the optional leading "!")
+// results in a Rotation which reports itself as invalid.
 func StringToRotation(p string) Rotation {
 	r := Rotation{}
 	if p == "" {
+		r.Degrees = -1
 		return r
 	}
 	if p[0:1] == "!" {
@@ -25,7 +26,12 @@ func StringToRotation(p string) Rotation {
 		p = p[1:]
 	}
 
-	r.Degrees, _ = strconv.ParseFloat(p, 64)
+	var err error
+	r.Degrees, err = strconv.ParseFloat(p, 64)
+	if err != nil {
+		r.Degrees = -1
+		return r
+	}
 
 	// This isn't actually to spec, but it makes way more sense than only
 	// allowing 360 for compliance level 2 (and in fact *requiring* it there)
@@ -36,8 +42,8 @@ func StringToRotation(p string) Rotation {
 	return r
 }
 
-// Valid just returns whether or not the degrees value is within a sane range:
-// 0 <= r.Degrees < 360
+// Valid returns false if the rotation string couldn't be parsed as a number,
+// or the degrees value is outside the sane range: 0 <= r.Degrees < 360
 func (r Rotation) Valid() bool {
 	return r.Degrees >= 0 && r.Degrees < 360
 }

--- a/src/iiif/rotation_test.go
+++ b/src/iiif/rotation_test.go
@@ -34,3 +34,10 @@ func TestInvalidRotation(t *testing.T) {
 	r = StringToRotation("!360.1")
 	assert.True(!r.Valid(), "!r.Valid", t)
 }
+
+func TestUnparseableRotation(t *testing.T) {
+	for _, s := range []string{"ca canny", "90foo", "!", "!abc", ""} {
+		r := StringToRotation(s)
+		assert.True(!r.Valid(), "StringToRotation("+s+") is invalid", t)
+	}
+}

--- a/src/iiif/url_test.go
+++ b/src/iiif/url_test.go
@@ -54,6 +54,6 @@ func TestInfo(t *testing.T) {
 
 func TestInfoBaseRedirect(t *testing.T) {
 	i, err := NewURL("some%2Fvalid%2Fpath.jp2")
-	assert.Equal("empty id, invalid region, invalid size, invalid quality", err.Error(), "base redirects are error cases the caller must handle", t)
+	assert.Equal("empty id, invalid region, invalid size, invalid rotation, invalid quality", err.Error(), "base redirects are error cases the caller must handle", t)
 	assert.Equal("", string(i.ID), "identifier", t)
 }


### PR DESCRIPTION
Fixes a IIIF validator failure by properly returning an error when a rotation string in the URI is invalid