### PR TITLE
Feature/performance

### DIFF
--- a/src/openjpeg/jp2_image.go
+++ b/src/openjpeg/jp2_image.go
@@ -7,13 +7,11 @@ import "C"
 import (
 	"fmt"
 	"image"
-	"image/color"
 	"rais/src/img"
 	"rais/src/jp2info"
+	"rais/src/transform"
 	"reflect"
 	"unsafe"
-
-	"golang.org/x/image/draw"
 )
 
 // JP2Image is a container for our simple JP2 operations
@@ -94,22 +92,10 @@ func (i *JP2Image) DecodeImage() (im image.Image, err error) {
 	// scaling would be a very expensive no-op
 	var db = decoded.Bounds()
 	if i.decodeWidth != db.Dx() || i.decodeHeight != db.Dy() {
-		var resized draw.Image
-		var rect = image.Rect(0, 0, i.decodeWidth, i.decodeHeight)
-
-		switch decoded.ColorModel() {
-		case color.RGBAModel:
-			resized = image.NewRGBA(rect)
-		case color.GrayModel:
-			resized = image.NewGray(rect)
-		case color.RGBA64Model:
-			resized = image.NewRGBA64(rect)
-		case color.Gray16Model:
-			resized = image.NewGray16(rect)
-		default:
-			return nil, fmt.Errorf("unsupported color model")
+		var resized = transform.Scale(decoded, i.decodeWidth, i.decodeHeight)
+		if resized == nil {
+			return nil, fmt.Errorf("unsupported image type %T", decoded)
 		}
-		draw.BiLinear.Scale(resized, rect, decoded, decoded.Bounds(), draw.Over, nil)
 		decoded = resized
 	}
 

--- a/src/openjpeg/jp2_image.go
+++ b/src/openjpeg/jp2_image.go
@@ -89,7 +89,11 @@ func (i *JP2Image) DecodeImage() (im image.Image, err error) {
 		return nil, fmt.Errorf("decoding raw JP2 data: %w", err)
 	}
 
-	if i.decodeWidth != i.decodeArea.Dx() || i.decodeHeight != i.decodeArea.Dy() {
+	// Only resample if the decoded image isn't already the target size: the
+	// progression-level decode often hands us exact dimensions, in which case
+	// scaling would be a very expensive no-op
+	var db = decoded.Bounds()
+	if i.decodeWidth != db.Dx() || i.decodeHeight != db.Dy() {
 		var resized draw.Image
 		var rect = image.Rect(0, 0, i.decodeWidth, i.decodeHeight)
 

--- a/src/openjpeg/jp2_image_test.go
+++ b/src/openjpeg/jp2_image_test.go
@@ -135,3 +135,44 @@ func BenchmarkReadAndDecodeTiledImage(b *testing.B) {
 		}
 	}
 }
+
+// benchmarkTiledImageResize decodes 2048x2048 regions of the tiled newspaper
+// image scaled down to the given dimensions, cycling through regions the same
+// way BenchmarkReadAndDecodeTiledImage does
+func benchmarkTiledImageResize(b *testing.B, width, height int) {
+	dir, _ := os.Getwd()
+	bigImage, err := img.NewFileStream(dir + "/../../docker/images/jp2tests/sn00063609-19091231.jp2")
+	if err != nil {
+		b.Fatalf("Unable to open file stream for newspaper image: %s", err)
+	}
+
+	for n := 0; n < b.N; n++ {
+		startX := (n % 2) * 2048
+		startY := ((n / 2) % 3) * 2048
+
+		jp2, err := NewJP2Image(bigImage)
+		if err != nil {
+			panic(err)
+		}
+		jp2.SetCrop(image.Rect(startX, startY, startX+2048, startY+2048))
+		jp2.SetResizeWH(width, height)
+		if _, err := jp2.DecodeImage(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+// BenchmarkReadAndDecodeTiledExactResize measures the common tile-serving
+// case where the requested scale lands exactly on a JP2 progression level
+// (2048x2048 down to 1024x1024): openjpeg hands back an image that's already
+// the right size, so resampling should cost (almost) nothing
+func BenchmarkReadAndDecodeTiledExactResize(b *testing.B) {
+	benchmarkTiledImageResize(b, 1024, 1024)
+}
+
+// BenchmarkReadAndDecodeTiledOddResize measures a scale that can't land on a
+// progression level (2048x2048 down to 1000x1000), forcing a real resample of
+// the 1024x1024 progression-level decode
+func BenchmarkReadAndDecodeTiledOddResize(b *testing.B) {
+	benchmarkTiledImageResize(b, 1000, 1000)
+}

--- a/src/transform/scale.go
+++ b/src/transform/scale.go
@@ -1,0 +1,176 @@
+package transform
+
+import (
+	"image"
+)
+
+// Scale resizes src to dstW x dstH using bilinear interpolation, returning
+// the scaled image.  Only the four concrete image types RAIS decoders produce
+// are supported (Gray, Gray16, RGBA, and RGBA64); anything else returns nil.
+//
+// These hand-rolled scalers exist because golang.org/x/image/draw only has
+// fast paths for *image.RGBA destinations: scaling grayscale or 16-bit images
+// with it goes through a generic per-pixel path that's over an order of
+// magnitude slower than this implementation.
+func Scale(src image.Image, dstW, dstH int) image.Image {
+	switch s := src.(type) {
+	case *image.Gray:
+		return ScaleGray(s, dstW, dstH)
+	case *image.Gray16:
+		return ScaleGray16(s, dstW, dstH)
+	case *image.RGBA:
+		return ScaleRGBA(s, dstW, dstH)
+	case *image.RGBA64:
+		return ScaleRGBA64(s, dstW, dstH)
+	}
+	return nil
+}
+
+// bilinearCoords precomputes, for each destination index along one axis, the
+// two source indexes to sample (relative to the source bounds) and the 16.16
+// fixed-point weight of the second sample.  Sample positions are
+// center-aligned: source position = (dst + 0.5) * srcDim/dstDim - 0.5.
+func bilinearCoords(srcDim, dstDim int) (i0, i1, frac []int) {
+	i0 = make([]int, dstDim)
+	i1 = make([]int, dstDim)
+	frac = make([]int, dstDim)
+	for x := 0; x < dstDim; x++ {
+		var c = (int64(2*x+1)*int64(srcDim)<<15)/int64(dstDim) - 1<<15
+		if c < 0 {
+			c = 0
+		}
+		var x0 = int(c >> 16)
+		var x1 = x0 + 1
+		if x1 > srcDim-1 {
+			x1 = srcDim - 1
+		}
+		i0[x], i1[x], frac[x] = x0, x1, int(c&0xffff)
+	}
+	return i0, i1, frac
+}
+
+// bilerp8 interpolates four 8-bit samples with 16.16 fixed-point x and y
+// weights, rounding to nearest
+func bilerp8(p00, p01, p10, p11 uint8, fx, fy int64) uint8 {
+	var top = int64(p00)<<16 + (int64(p01)-int64(p00))*fx
+	var bot = int64(p10)<<16 + (int64(p11)-int64(p10))*fx
+	return uint8((top<<16 + (bot-top)*fy + 1<<31) >> 32)
+}
+
+// bilerp16 interpolates four 16-bit samples with 16.16 fixed-point x and y
+// weights, rounding to nearest
+func bilerp16(p00, p01, p10, p11 uint16, fx, fy int64) uint16 {
+	var top = int64(p00)<<16 + (int64(p01)-int64(p00))*fx
+	var bot = int64(p10)<<16 + (int64(p11)-int64(p10))*fx
+	return uint16((top<<16 + (bot-top)*fy + 1<<31) >> 32)
+}
+
+// be16 reads a big-endian uint16 from pix at offset o
+func be16(pix []uint8, o int) uint16 {
+	return uint16(pix[o])<<8 | uint16(pix[o+1])
+}
+
+// putbe16 writes v to pix at offset o in big-endian order
+func putbe16(pix []uint8, o int, v uint16) {
+	pix[o] = uint8(v >> 8)
+	pix[o+1] = uint8(v)
+}
+
+// ScaleGray resizes src to dstW x dstH using bilinear interpolation
+func ScaleGray(src *image.Gray, dstW, dstH int) *image.Gray {
+	var dst = image.NewGray(image.Rect(0, 0, dstW, dstH))
+	var b = src.Bounds()
+	var x0s, x1s, xfs = bilinearCoords(b.Dx(), dstW)
+	var y0s, y1s, yfs = bilinearCoords(b.Dy(), dstH)
+	var base = src.PixOffset(b.Min.X, b.Min.Y)
+
+	for y := 0; y < dstH; y++ {
+		var row0 = src.Pix[base+y0s[y]*src.Stride:]
+		var row1 = src.Pix[base+y1s[y]*src.Stride:]
+		var fy = int64(yfs[y])
+		var drow = dst.Pix[y*dst.Stride : y*dst.Stride+dstW]
+		for x := 0; x < dstW; x++ {
+			var x0, x1, fx = x0s[x], x1s[x], int64(xfs[x])
+			drow[x] = bilerp8(row0[x0], row0[x1], row1[x0], row1[x1], fx, fy)
+		}
+	}
+
+	return dst
+}
+
+// ScaleGray16 resizes src to dstW x dstH using bilinear interpolation
+func ScaleGray16(src *image.Gray16, dstW, dstH int) *image.Gray16 {
+	var dst = image.NewGray16(image.Rect(0, 0, dstW, dstH))
+	var b = src.Bounds()
+	var x0s, x1s, xfs = bilinearCoords(b.Dx(), dstW)
+	var y0s, y1s, yfs = bilinearCoords(b.Dy(), dstH)
+	var base = src.PixOffset(b.Min.X, b.Min.Y)
+
+	for y := 0; y < dstH; y++ {
+		var row0 = src.Pix[base+y0s[y]*src.Stride:]
+		var row1 = src.Pix[base+y1s[y]*src.Stride:]
+		var fy = int64(yfs[y])
+		var drow = dst.Pix[y*dst.Stride:]
+		for x := 0; x < dstW; x++ {
+			var s0, s1, fx = x0s[x] << 1, x1s[x] << 1, int64(xfs[x])
+			putbe16(drow, x<<1, bilerp16(be16(row0, s0), be16(row0, s1), be16(row1, s0), be16(row1, s1), fx, fy))
+		}
+	}
+
+	return dst
+}
+
+// ScaleRGBA resizes src to dstW x dstH using bilinear interpolation.  All
+// four channels are interpolated independently, which is correct for the
+// premultiplied alpha RGBA uses.
+func ScaleRGBA(src *image.RGBA, dstW, dstH int) *image.RGBA {
+	var dst = image.NewRGBA(image.Rect(0, 0, dstW, dstH))
+	var b = src.Bounds()
+	var x0s, x1s, xfs = bilinearCoords(b.Dx(), dstW)
+	var y0s, y1s, yfs = bilinearCoords(b.Dy(), dstH)
+	var base = src.PixOffset(b.Min.X, b.Min.Y)
+
+	for y := 0; y < dstH; y++ {
+		var row0 = src.Pix[base+y0s[y]*src.Stride:]
+		var row1 = src.Pix[base+y1s[y]*src.Stride:]
+		var fy = int64(yfs[y])
+		var drow = dst.Pix[y*dst.Stride:]
+		for x := 0; x < dstW; x++ {
+			var s0, s1, fx = x0s[x] << 2, x1s[x] << 2, int64(xfs[x])
+			var o = x << 2
+			drow[o] = bilerp8(row0[s0], row0[s1], row1[s0], row1[s1], fx, fy)
+			drow[o+1] = bilerp8(row0[s0+1], row0[s1+1], row1[s0+1], row1[s1+1], fx, fy)
+			drow[o+2] = bilerp8(row0[s0+2], row0[s1+2], row1[s0+2], row1[s1+2], fx, fy)
+			drow[o+3] = bilerp8(row0[s0+3], row0[s1+3], row1[s0+3], row1[s1+3], fx, fy)
+		}
+	}
+
+	return dst
+}
+
+// ScaleRGBA64 resizes src to dstW x dstH using bilinear interpolation.  All
+// four channels are interpolated independently, which is correct for the
+// premultiplied alpha RGBA64 uses.
+func ScaleRGBA64(src *image.RGBA64, dstW, dstH int) *image.RGBA64 {
+	var dst = image.NewRGBA64(image.Rect(0, 0, dstW, dstH))
+	var b = src.Bounds()
+	var x0s, x1s, xfs = bilinearCoords(b.Dx(), dstW)
+	var y0s, y1s, yfs = bilinearCoords(b.Dy(), dstH)
+	var base = src.PixOffset(b.Min.X, b.Min.Y)
+
+	for y := 0; y < dstH; y++ {
+		var row0 = src.Pix[base+y0s[y]*src.Stride:]
+		var row1 = src.Pix[base+y1s[y]*src.Stride:]
+		var fy = int64(yfs[y])
+		var drow = dst.Pix[y*dst.Stride:]
+		for x := 0; x < dstW; x++ {
+			var s0, s1, fx = x0s[x] << 3, x1s[x] << 3, int64(xfs[x])
+			var o = x << 3
+			for c := 0; c < 8; c += 2 {
+				putbe16(drow, o+c, bilerp16(be16(row0, s0+c), be16(row0, s1+c), be16(row1, s0+c), be16(row1, s1+c), fx, fy))
+			}
+		}
+	}
+
+	return dst
+}

--- a/src/transform/scale_test.go
+++ b/src/transform/scale_test.go
@@ -1,0 +1,222 @@
+package transform
+
+import (
+	"fmt"
+	"image"
+	"testing"
+
+	"github.com/uoregon-libraries/gopkg/assert"
+)
+
+// lcg gives us deterministic pseudo-random pixel data
+type lcg uint32
+
+func (l *lcg) next() uint8 {
+	*l = *l*1664525 + 1013904223
+	return uint8(*l >> 24)
+}
+
+func randomImage(kind string, r image.Rectangle) image.Image {
+	var seed = lcg(0x1234)
+	switch kind {
+	case "Gray":
+		var i = image.NewGray(r)
+		for n := range i.Pix {
+			i.Pix[n] = seed.next()
+		}
+		return i
+	case "Gray16":
+		var i = image.NewGray16(r)
+		for n := range i.Pix {
+			i.Pix[n] = seed.next()
+		}
+		return i
+	case "RGBA":
+		var i = image.NewRGBA(r)
+		for n := range i.Pix {
+			i.Pix[n] = seed.next()
+		}
+		return i
+	case "RGBA64":
+		var i = image.NewRGBA64(r)
+		for n := range i.Pix {
+			i.Pix[n] = seed.next()
+		}
+		return i
+	}
+	panic("bad image kind " + kind)
+}
+
+// refChannels computes a float64 reference bilinear interpolation for the dst
+// pixel (x, y), returning the four channels in the 16-bit space At().RGBA()
+// uses.  This mirrors the center-aligned sampling Scale is supposed to do.
+func refChannels(src image.Image, dstW, dstH, x, y int) [4]float64 {
+	var b = src.Bounds()
+	var sample = func(sx, sy int) [4]float64 {
+		var r, g, bl, a = src.At(b.Min.X+sx, b.Min.Y+sy).RGBA()
+		return [4]float64{float64(r), float64(g), float64(bl), float64(a)}
+	}
+	var coords = func(d, dstDim, srcDim int) (int, int, float64) {
+		var c = (float64(d)+0.5)*float64(srcDim)/float64(dstDim) - 0.5
+		if c < 0 {
+			c = 0
+		}
+		var i0 = int(c)
+		var i1 = i0 + 1
+		if i1 > srcDim-1 {
+			i1 = srcDim - 1
+		}
+		return i0, i1, c - float64(i0)
+	}
+
+	var x0, x1, fx = coords(x, dstW, b.Dx())
+	var y0, y1, fy = coords(y, dstH, b.Dy())
+	var p00, p01 = sample(x0, y0), sample(x1, y0)
+	var p10, p11 = sample(x0, y1), sample(x1, y1)
+	var out [4]float64
+	for c := 0; c < 4; c++ {
+		var top = p00[c] + (p01[c]-p00[c])*fx
+		var bot = p10[c] + (p11[c]-p10[c])*fx
+		out[c] = top + (bot-top)*fy
+	}
+	return out
+}
+
+func assertMatchesReference(t *testing.T, src image.Image, dstW, dstH int, tolerance float64) {
+	var dst = Scale(src, dstW, dstH)
+	if dst == nil {
+		t.Fatalf("Scale returned nil for %T", src)
+	}
+	var b = dst.Bounds()
+	assert.Equal(dstW, b.Dx(), "scaled width", t)
+	assert.Equal(dstH, b.Dy(), "scaled height", t)
+
+	for y := 0; y < dstH; y++ {
+		for x := 0; x < dstW; x++ {
+			var ref = refChannels(src, dstW, dstH, x, y)
+			var r, g, bl, a = dst.At(x, y).RGBA()
+			var got = [4]float64{float64(r), float64(g), float64(bl), float64(a)}
+			for c := 0; c < 4; c++ {
+				var diff = got[c] - ref[c]
+				if diff < 0 {
+					diff = -diff
+				}
+				if diff > tolerance {
+					t.Fatalf("%T scale %dx%d -> %dx%d: pixel (%d, %d) channel %d: got %f, want %f (tolerance %f)",
+						src, src.Bounds().Dx(), src.Bounds().Dy(), dstW, dstH, x, y, c, got[c], ref[c], tolerance)
+				}
+			}
+		}
+	}
+}
+
+func TestScaleMatchesReference(t *testing.T) {
+	// 8-bit channels are reported by RGBA() in 16-bit space (one unit is 257),
+	// so rounding to the nearest 8-bit value can differ from the float
+	// reference by up to half a unit
+	var tolerances = map[string]float64{"Gray": 130, "RGBA": 130, "Gray16": 2, "RGBA64": 2}
+	var sizes = []struct{ sw, sh, dw, dh int }{
+		{13, 7, 29, 17},  // upscale
+		{64, 48, 31, 23}, // non-integer downscale
+		{32, 32, 16, 16}, // exact 2:1
+		{20, 20, 20, 20}, // same size
+		{16, 16, 1, 1},   // extreme downscale
+	}
+	for kind, tolerance := range tolerances {
+		for _, s := range sizes {
+			t.Run(fmt.Sprintf("%s_%dx%d_to_%dx%d", kind, s.sw, s.sh, s.dw, s.dh), func(t *testing.T) {
+				assertMatchesReference(t, randomImage(kind, image.Rect(0, 0, s.sw, s.sh)), s.dw, s.dh, tolerance)
+			})
+		}
+	}
+}
+
+// TestScaleSubImage ensures sources with non-zero bounds (e.g., from
+// SubImage) are read from the right place
+func TestScaleSubImage(t *testing.T) {
+	var full = randomImage("Gray", image.Rect(0, 0, 64, 64)).(*image.Gray)
+	var sub = full.SubImage(image.Rect(16, 8, 48, 40)).(*image.Gray)
+	assertMatchesReference(t, sub, 16, 16, 130)
+
+	var full16 = randomImage("RGBA64", image.Rect(0, 0, 64, 64)).(*image.RGBA64)
+	var sub16 = full16.SubImage(image.Rect(16, 8, 48, 40)).(*image.RGBA64)
+	assertMatchesReference(t, sub16, 16, 16, 2)
+}
+
+// TestScaleConstant verifies a solid-color image stays exactly solid - any
+// deviation means our weights don't sum to one
+func TestScaleConstant(t *testing.T) {
+	var src = image.NewGray16(image.Rect(0, 0, 50, 30))
+	for n := 0; n < len(src.Pix); n += 2 {
+		src.Pix[n], src.Pix[n+1] = 0xBE, 0xEF
+	}
+	var dst = Scale(src, 33, 21).(*image.Gray16)
+	for n := 0; n < len(dst.Pix); n += 2 {
+		if dst.Pix[n] != 0xBE || dst.Pix[n+1] != 0xEF {
+			t.Fatalf("constant image changed at pix offset %d: %#x%x", n, dst.Pix[n], dst.Pix[n+1])
+		}
+	}
+}
+
+// TestScaleCheckerboard verifies an exact 2:1 downscale of a checkerboard
+// averages each 2x2 block (the half-pixel weights make this case exact)
+func TestScaleCheckerboard(t *testing.T) {
+	var src = image.NewGray(image.Rect(0, 0, 32, 32))
+	for y := 0; y < 32; y++ {
+		for x := 0; x < 32; x++ {
+			if (x+y)%2 == 0 {
+				src.Pix[y*src.Stride+x] = 255
+			}
+		}
+	}
+	var dst = Scale(src, 16, 16).(*image.Gray)
+	for n, p := range dst.Pix {
+		// 127.5 rounds up
+		if p != 128 {
+			t.Fatalf("checkerboard downscale: expected 128 at pix %d, got %d", n, p)
+		}
+	}
+}
+
+func TestScaleUnsupportedType(t *testing.T) {
+	var dst = Scale(image.NewNRGBA(image.Rect(0, 0, 8, 8)), 4, 4)
+	if dst != nil {
+		t.Fatalf("expected nil for unsupported image type, got %T", dst)
+	}
+}
+
+func benchSetup(kind string) image.Image {
+	return randomImage(kind, image.Rect(0, 0, 2048, 2048))
+}
+
+func BenchmarkScaleGray(b *testing.B) {
+	var src = benchSetup("Gray")
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		Scale(src, 1024, 1024)
+	}
+}
+
+func BenchmarkScaleRGBA(b *testing.B) {
+	var src = benchSetup("RGBA")
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		Scale(src, 1024, 1024)
+	}
+}
+
+func BenchmarkScaleGray16(b *testing.B) {
+	var src = benchSetup("Gray16")
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		Scale(src, 1024, 1024)
+	}
+}
+
+func BenchmarkScaleRGBA64(b *testing.B) {
+	var src = benchSetup("RGBA64")
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		Scale(src, 1024, 1024)
+	}
+}


### PR DESCRIPTION
Fixes a major performance regression for simple tile requests (introduced in RAIS v4.2.0 when adding support for 16-bit images), and dramatically improves performance when delivering thumbnail, "edge" tiles, and custom tile sizes (as seen in ONI's "Clip/Print image" feature).

All users will see major performance improvements. Some users will see RAIS running more like it was before the regression, but most will also see major improvements beyond that.